### PR TITLE
Updating dead link.

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 				
 				<noscript><p class="error">This tool requires Javascript.</p></noscript>
 			
-				<p class="lib-alert">Serials Solutions <a href="http://www.serialssolutions.com/words/the-summon-service-introduces-discipline-scoped-searching-and-widgets/">has a powerful tool for building scoped searches</a>. Use it if you can embed Javascript on your webpage. If not, this tool creates the same search with good old <abbr title="HyperText Markup Language">HTML</abbr>.</p>
+				<p class="lib-alert">Serials Solutions <a href="http://proquest.libguides.com/summon/librarians#s-lg-col-2">has a powerful tool for building scoped searches</a>. Use it if you can embed Javascript on your webpage. If not, this tool creates the same search with good old <abbr title="HyperText Markup Language">HTML</abbr>.</p>
 				
 				<p>Summon searches nearly all of our holdings by default. To create a more targeted search, select limiters below and copy the <abbr title="HyperText Markup Language">HTML</abbr> from the bottom of the page to insert into any website.</p>
 											


### PR DESCRIPTION
The link to Summon's announcement about the widget builder no longer goes anywhere useful. I found a link to one of ProQuest's LibGuides. It's not _perfect_, but at least it explains where to find the widget builder. I've anchored this link to the box of information we care about.
